### PR TITLE
[setup] Move import to FFi directly in Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ To install this package, you need to have a compiler present on your system (`gc
 
 5. Restart if required
 
-You can run the `setup.py` file using:
+You can install this package using pip:
+```bash
+pip install .
 ```
-python setup.py install
+or using the following if you want to install it in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs), meaning that if you update the code, the installed package will be updated as well:
+```bash
+pip install -e .
 ```
+
 The package should compile the libraries when installed (creates `.pyd` files on windows, `.so` files on linux, haven't tested on mac), and copy them over to the proper install location.
 
 ## Use example

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-from setuptools.command.install import install
-from setuptools.command.develop import develop
+from distutils.command.build import build
 
-from cffi import FFI
 from os import remove
 import setuptools  # necessary magic import for windows -- don't think, just accept it!
 
@@ -39,6 +37,7 @@ def compile_library():
         int c_fseek(FILE *, long int);"""
 
     for code in codes_dict:
+        from cffi import FFI
         ffibuilder = FFI()
         ffibuilder.cdef(prototypes)
         ffibuilder.set_source("readPTU._readTTTRRecords_{}".format(code),
@@ -47,23 +46,12 @@ def compile_library():
         print('\nCompiling version {}'.format(code))
         ffibuilder.compile(verbose=True)
         remove('./readPTU/_readTTTRRecords_{}.c'.format(code))
-        # remove('./readPTU/_readTTTRRecords_{}.o'.format(code))
 
 
-class Build(install):
-    """Custom handler for the 'install' command."""
-
+class Build(build):
     def run(self):
         compile_library()
-        install.run(self)
-
-class Build_dev(develop):
-    """Custom handler for the 'install' command."""
-
-    def run(self):
-        compile_library()
-        develop.run(self)
-
+        super().run()
 
 setuptools.setup(
     name='readPTU',
@@ -76,6 +64,6 @@ setuptools.setup(
     packages=['readPTU'],
     zip_safe=False,
     setup_requires=["cffi>=1.11.2"],
-    install_requires=["cffi>=1.11.2"],
-    cmdclass={'install': Build, 'develop': Build_dev},
+    install_requires=["cffi>=1.11.2", "matplotlib"],
+    cmdclass={'build': Build},
     package_data={'': ['*.so', '*.c', '*.o', '*.pyd']}) # Note that we also have to include .pyd files for binaries to be copied over on windows


### PR DESCRIPTION
Hello, 
I have an issue when trying to install your package:
```bash
python3 -m pip install git+https://github.com/QuantumPhotonicsLab/readPTU.git
Collecting git+https://github.com/QuantumPhotonicsLab/readPTU.git
  Cloning https://github.com/QuantumPhotonicsLab/readPTU.git to /private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor
  Running command git clone -q https://github.com/QuantumPhotonicsLab/readPTU.git /private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor
    ERROR: Command errored out with exit status 1:
     command: /Users/antoine/movexplo/env/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor/setup.py'"'"'; __file__='"'"'/private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor/pip-egg-info
         cwd: /private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/r7/wn2zm4pd5g137j4wf12279k80000gn/T/pip-req-build-l2m3kdor/setup.py", line 4, in <module>
        from cffi import FFI
    ModuleNotFoundError: No module named 'cffi'
    ----------------------------------------
```

This PR should solve this by moving the import in the Builder. I made sure my solution worked by executing `pip install .` without `cffi` already installed


I also modified the `setup.py` to move the compile operations from the install to the build step, so that `pip install .` also works.